### PR TITLE
broken out NotificationParser to decouple from required use of HttpListenerRequest

### DIFF
--- a/Riskified.SDK/Notifications/NotificationHandler.cs
+++ b/Riskified.SDK/Notifications/NotificationHandler.cs
@@ -94,8 +94,8 @@ namespace Riskified.SDK.Notifications
                     bool acionSucceeded = false;
                     try
                     {
-                        var notificationData = HttpUtils.ParsePostRequestToObject<OrderWrapper<Notification>>(request,_authToken);
-                        OrderNotification n = new OrderNotification(notificationData);
+                        OrderNotification n = NotificationParser.ParseListenerRequest(request, _authToken);
+                        
                         responseString =
                                 string.Format(
                                     "<HTML><BODY>Merchant Received Notification For Order {0} with status {1} and description {2}</BODY></HTML>",

--- a/Riskified.SDK/Notifications/NotificationParser.cs
+++ b/Riskified.SDK/Notifications/NotificationParser.cs
@@ -1,0 +1,24 @@
+﻿using System.Net;
+using Riskified.SDK.Model;
+using Riskified.SDK.Model.Internal;
+using Riskified.SDK.Utils;
+
+namespace Riskified.SDK.Notifications
+{
+    public static class NotificationParser
+    {
+        public static string HmacHeaderName => HttpUtils.HmacHeaderName;
+
+        public static OrderNotification ParseListenerRequest(HttpListenerRequest request, string authToken)
+        {
+            var notificationData = HttpUtils.ParsePostRequestToObject<OrderWrapper<Notification>>(request, authToken);
+            return new OrderNotification(notificationData);
+        }
+
+        public static OrderNotification ParseRequestComponents(string hmacHeader, string requestBody, string authToken)
+        {
+            var notificationData = HttpUtils.ParsePostRequestComponentsToObject<OrderWrapper<Notification>>(hmacHeader, requestBody, authToken);
+            return new OrderNotification(notificationData);
+        }
+    }
+}

--- a/Riskified.SDK/Orders/OrdersGateway.cs
+++ b/Riskified.SDK/Orders/OrdersGateway.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Riskified.SDK.Exceptions;
 using Riskified.SDK.Model;
 using Riskified.SDK.Utils;


### PR DESCRIPTION
Created a simple utility class to allow for notification parsing, mainly to decouple from required use of `HttpListenerRequest`