### PR TITLE
DEV-126104: add optional field `totalSpent` and bump SDK version for 5.1.0

### DIFF
--- a/Riskified.SDK/Model/OrderElements/Customer.cs
+++ b/Riskified.SDK/Model/OrderElements/Customer.cs
@@ -20,7 +20,7 @@ namespace Riskified.SDK.Model.OrderElements
         /// <param name="verifiedEmail">Signs if the email was verified by the merchant is some way (optional)</param>
         /// <param name="createdAt">The time of creation of the customer card (optional)</param>
         /// <param name="notes">Additional notes regarding the customer (optional)</param>
-        public Customer(string firstName, string lastName, string id, int? ordersCount = null, string email = null, bool? verifiedEmail = null, DateTimeOffset? verifiedEmailAt = null, bool? verifiedPhone = null, DateTimeOffset? verifiedPhoneAt = null, DateTimeOffset? createdAt = null, DateTimeOffset? updatedAt = null,  string notes = null, SocialDetails[] social = null, BasicAddress address = null, string accountType = null, int? linkedAccounts = null, DateTimeOffset? firstPurchaseAt = null, string documentId = null, string documentType = null)
+        public Customer(string firstName, string lastName, string id, int? ordersCount = null, string email = null, bool? verifiedEmail = null, DateTimeOffset? verifiedEmailAt = null, bool? verifiedPhone = null, DateTimeOffset? verifiedPhoneAt = null, DateTimeOffset? createdAt = null, DateTimeOffset? updatedAt = null,  string notes = null, SocialDetails[] social = null, BasicAddress address = null, string accountType = null, int? linkedAccounts = null, DateTimeOffset? firstPurchaseAt = null, string documentId = null, string documentType = null, float? totalSpent = null)
         {
             FirstName = firstName;
             LastName = lastName;
@@ -43,6 +43,7 @@ namespace Riskified.SDK.Model.OrderElements
             FirstPurchaseAt = firstPurchaseAt;
             DocumentId = documentId;
             DocumentType = documentType;
+            TotalSpent = totalSpent;
         }
 
         /// <summary>
@@ -94,6 +95,10 @@ namespace Riskified.SDK.Model.OrderElements
             {
                 InputValidators.ValidateDateNotDefault(FirstPurchaseAt.Value, "First Purchase At");
             }
+            if (TotalSpent.HasValue)
+            {
+                InputValidators.ValidateZeroOrPositiveValue(TotalSpent.Value, "Total Spent");
+            }
             if (Social != null)
             {
                 Social.ToList().ForEach(item => item.Validate(validationType));
@@ -127,6 +132,9 @@ namespace Riskified.SDK.Model.OrderElements
 
         [JsonProperty(PropertyName = "orders_count")]
         public int? OrdersCount { get; set; }
+
+        [JsonProperty(PropertyName = "total_spent")]
+        public float? TotalSpent { get; set; }
 
         [JsonProperty(PropertyName = "verified_email")]
         public bool? VerifiedEmail { get; set; }

--- a/Riskified.SDK/Riskified.SDK.csproj
+++ b/Riskified.SDK/Riskified.SDK.csproj
@@ -9,7 +9,7 @@
     
     <!-- NuGet Package Properties -->
     <PackageId>Riskified.SDK</PackageId>
-    <Version>5.0.1</Version>
+    <Version>5.1.0</Version>
     <Authors>Riskified</Authors>
     <Company>Riskified</Company>
     <Product>Riskified.SDK</Product>


### PR DESCRIPTION
📌 **Related Issues:** [DEV-126104](https://riskified.atlassian.net/browse/DEV-126104)

- [X] 🚀 Feature
- [ ] 🐛 Bugfix
- [ ] 🔨 Refactor
- [ ] 🧪 Tests
- [X] 🧹 Chore / Maintenance
- [ ] 📄 Documentation

## 📝 Problem Statement

The .NET SDK `Customer` model was missing support for an optional field now required by a merchant integration:

- `order.customer.total_spent` (number)

Without this field in the model definition, the SDK cannot fully represent the customer payload sent to Riskified.

## 📝 Solution Overview

Updated the `Customer` model to include optional `total_spent` support and bumped SDK minor version.

- `Riskified.SDK/Model/OrderElements/Customer.cs`
  - Added constructor parameter: `float? totalSpent = null`
  - Added JSON mapping: `total_spent`
  - Added validation: non-negative value (`ValidateZeroOrPositiveValue`)
- `Riskified.SDK/Riskified.SDK.csproj`
  - Bumped package version from `5.0.1` to `5.1.0`

[DEV-126104]: https://riskified.atlassian.net/browse/DEV-126104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ