### PR TITLE
DEV-126501 | add field to order & payment details

### DIFF
--- a/Riskified.SDK/Model/OrderBase.cs
+++ b/Riskified.SDK/Model/OrderBase.cs
@@ -1,10 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Riskified.SDK.Model.OrderElements;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Riskified.SDK.Model
 {
@@ -185,7 +181,10 @@ namespace Riskified.SDK.Model
         public string OrderType { get; set; }
         
         [JsonProperty(PropertyName = "custom")]
-        public Custom Custom { get; set; } 
+        public Custom Custom { get; set; }
+
+        [JsonProperty(PropertyName = "partner_sub_merchant_id")]
+        public string PartnerSubMerchantId { get; set; } = null;
 
     }
 }

--- a/Riskified.SDK/Model/OrderElements/BankWirePaymentDetails.cs
+++ b/Riskified.SDK/Model/OrderElements/BankWirePaymentDetails.cs
@@ -43,5 +43,8 @@ namespace Riskified.SDK.Model.OrderElements
 
         [JsonProperty(PropertyName = "recipient_name")]
         public string RecipientName { get; set; }
+
+        [JsonProperty(PropertyName = "payment_type")]
+        public PaymentType PaymentType { get; } = PaymentType.BankTransfer;
     }
 }

--- a/Riskified.SDK/Model/OrderElements/CreditCardPaymentDetails.cs
+++ b/Riskified.SDK/Model/OrderElements/CreditCardPaymentDetails.cs
@@ -3,14 +3,12 @@ using System;
 using Riskified.SDK.Exceptions;
 using Riskified.SDK.Model.OrderCheckoutElements;
 using Riskified.SDK.Utils;
-using System.Runtime.Serialization;
-using Newtonsoft.Json.Converters;
 
 namespace Riskified.SDK.Model.OrderElements
 {
     public class CreditCardPaymentDetails : IPaymentDetails
     {
-       
+
 
         /// <summary>
         /// The payment information for the order
@@ -22,12 +20,12 @@ namespace Riskified.SDK.Model.OrderElements
         /// <param name="creditCardNumber">The 4 last digits of the customer's credit card number, with most of the leading digits redacted with Xs</param>
         /// <param name="authorizationId">Unique identifier of the payment transaction as granted by the processing gateway.</param>
         public CreditCardPaymentDetails(string avsResultCode,
-                                        string cvvResultCode, 
-                                        string creditCardBin, 
-                                        string creditCardCompany, 
-                                        string creditCardNumber, 
+                                        string cvvResultCode,
+                                        string creditCardBin,
+                                        string creditCardCompany,
+                                        string creditCardNumber,
                                         string authorizationId = null,
-                                        string creditCardToken = null, 
+                                        string creditCardToken = null,
                                         DateTimeOffset? storedPaymentCreatedAt = null,
                                         DateTimeOffset? storedPaymentUpdatedAt = null,
                                         int? installments = null)
@@ -59,13 +57,13 @@ namespace Riskified.SDK.Model.OrderElements
                 InputValidators.ValidateCvvResultCode(CvvResultCode);
                 InputValidators.ValidateCreditCard(CreditCardNumber);
             }
-            
+
             InputValidators.ValidateValuedString(CreditCardBin, "Credit Card Bin");
             InputValidators.ValidateValuedString(CreditCardCompany, "Credit Card Company");
         }
 
 
-        
+
         [JsonProperty(PropertyName = "avs_result_code")]
         public string AvsResultCode { get; set; }
 
@@ -131,6 +129,9 @@ namespace Riskified.SDK.Model.OrderElements
 
         [JsonProperty(PropertyName = "verification_type")]
         public string VerificationType { get; set; }
+
+        [JsonProperty(PropertyName = "payment_type")]
+        public PaymentType PaymentType { get; } = PaymentType.Card;
     }
 
 }

--- a/Riskified.SDK/Model/OrderElements/CreditCardPaymentDetails.cs
+++ b/Riskified.SDK/Model/OrderElements/CreditCardPaymentDetails.cs
@@ -8,11 +8,6 @@ using Newtonsoft.Json.Converters;
 
 namespace Riskified.SDK.Model.OrderElements
 {
-    [Obsolete("PaymentType not in use anymore", true)]
-    public enum PaymentType
-    {
-        credit_card, paypal
-    }
     public class CreditCardPaymentDetails : IPaymentDetails
     {
        

--- a/Riskified.SDK/Model/OrderElements/PaymentType.cs
+++ b/Riskified.SDK/Model/OrderElements/PaymentType.cs
@@ -1,0 +1,54 @@
+using System.Runtime.Serialization;
+
+namespace Riskified.SDK.Model.OrderElements
+{
+    public enum PaymentType
+    {
+        [EnumMember(Value = "card")]
+        Card,
+        [EnumMember(Value = "apple_pay")]
+        ApplePay,
+        [EnumMember(Value = "google_pay")]
+        GooglePay,
+        [EnumMember(Value = "samsung_pay")]
+        SamsungPay,
+        [EnumMember(Value = "paypal")]
+        Paypal,
+        [EnumMember(Value = "shop_pay")]
+        ShopPay,
+        [EnumMember(Value = "amazon_pay")]
+        AmazonPay,
+        [EnumMember(Value = "bnpl")]
+        Bnpl,
+        [EnumMember(Value = "bank_transfer")]
+        BankTransfer,
+        [EnumMember(Value = "ach")]
+        Ach,
+        [EnumMember(Value = "crypto")]
+        Crypto,
+        [EnumMember(Value = "gift_card")]
+        GiftCard,
+        [EnumMember(Value = "store_credit")]
+        StoreCredit,
+        [EnumMember(Value = "cash_on_delivery")]
+        CashOnDelivery,
+        [EnumMember(Value = "invoice")]
+        Invoice,
+        [EnumMember(Value = "reward_points")]
+        RewardPoints,
+        [EnumMember(Value = "mobile_carrier")]
+        MobileCarrier,
+        [EnumMember(Value = "cashe")]
+        Cashe,
+        [EnumMember(Value = "check")]
+        Check,
+        [EnumMember(Value = "boleto")]
+        Boleto,
+        [EnumMember(Value = "wechat_pay")]
+        WechatPay,
+        [EnumMember(Value = "alipay")]
+        Alipay,
+        [EnumMember(Value = "other")]
+        Other
+    }
+}

--- a/Riskified.SDK/Model/OrderElements/PaypalPaymentDetails.cs
+++ b/Riskified.SDK/Model/OrderElements/PaypalPaymentDetails.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+﻿using Newtonsoft.Json;
 using Riskified.SDK.Exceptions;
 using Riskified.SDK.Model.OrderCheckoutElements;
 using Riskified.SDK.Utils;
@@ -19,8 +17,8 @@ namespace Riskified.SDK.Model.OrderElements
         /// <param name="payerAddressStatus">The payer address status as received from paypal</param>
         /// <param name="protectionEligibility">The merchants protection eligibility for the order as received from paypal</param>
         /// <param name="pendingReason">The pending reason received from paypal</param>
-        public PaypalPaymentDetails(string paymentStatus, string authorizationId = null, string payerEmail = null, string payerStatus = null, string payerAddressStatus = null , 
-            string protectionEligibility = null , string pendingReason = null)
+        public PaypalPaymentDetails(string paymentStatus, string authorizationId = null, string payerEmail = null, string payerStatus = null, string payerAddressStatus = null,
+            string protectionEligibility = null, string pendingReason = null)
         {
             AuthorizationId = authorizationId;
             PayerEmail = payerEmail;
@@ -28,7 +26,7 @@ namespace Riskified.SDK.Model.OrderElements
             PayerAddressStatus = payerAddressStatus;
             ProtectionEligibility = protectionEligibility;
             PaymentStatus = paymentStatus;
-            PendingReason = PendingReason;
+            PendingReason = pendingReason;
         }
 
         /// <summary>
@@ -44,7 +42,7 @@ namespace Riskified.SDK.Model.OrderElements
             }
         }
 
-        
+
         [JsonProperty(PropertyName = "authorization_id")]
         public string AuthorizationId { get; set; }
 
@@ -71,6 +69,9 @@ namespace Riskified.SDK.Model.OrderElements
 
         [JsonProperty(PropertyName = "authentication_result")]
         public AuthorizationError AuthorizationResult { get; set; }
+
+        [JsonProperty(PropertyName = "payment_type")]
+        public PaymentType PaymentType { get; } = PaymentType.Paypal;
 
     }
 }


### PR DESCRIPTION
Add payment type for all implementations of `IPaymentDetails`, which are:
- CreditCard
- Paypal
- BankTransfer (BankWire)

Add `partner_sub_merchant_id` optional field to order