### PR TITLE
DEV-131521: Add account_identity and account_balance support to BankWirePaymentDetails

### DIFF
--- a/Riskified.SDK/Model/OrderElements/AccountBalance.cs
+++ b/Riskified.SDK/Model/OrderElements/AccountBalance.cs
@@ -1,0 +1,56 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Riskified.SDK.Exceptions;
+using Riskified.SDK.Utils;
+
+namespace Riskified.SDK.Model.OrderElements
+{
+    /// <summary>
+    /// Represents account balance information from a financial data provider.
+    /// All fields are required.
+    /// </summary>
+    public class AccountBalance : IJsonSerializable
+    {
+        /// <summary>
+        /// Creates an AccountBalance instance with all required fields
+        /// </summary>
+        /// <param name="availableBalance">The available balance in the account</param>
+        /// <param name="serviceName">The financial data service provider</param>
+        /// <param name="updatedAt">When the balance was last updated (ISO 8601)</param>
+        /// <param name="currencyCode">The currency code (ISO 4217)</param>
+        public AccountBalance(double availableBalance, AccountBalanceServiceName serviceName, DateTimeOffset updatedAt, string currencyCode)
+        {
+            AvailableBalance = availableBalance;
+            ServiceName = serviceName;
+            UpdatedAt = updatedAt;
+            CurrencyCode = currencyCode;
+        }
+
+        /// <summary>
+        /// Validates the object's fields content
+        /// </summary>
+        /// <param name="validationType">Should use weak validations or strong</param>
+        /// <exception cref="OrderFieldBadFormatException">throws an exception if one of the parameters doesn't match the expected format</exception>
+        public void Validate(Validations validationType = Validations.Weak)
+        {
+            if (validationType != Validations.Weak)
+            {
+                InputValidators.ValidateValuedString(CurrencyCode, "Currency Code");
+            }
+        }
+
+        [JsonProperty(PropertyName = "available_balance")]
+        public double AvailableBalance { get; set; }
+
+        [JsonProperty(PropertyName = "service_name")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public AccountBalanceServiceName ServiceName { get; set; }
+
+        [JsonProperty(PropertyName = "updated_at")]
+        public DateTimeOffset UpdatedAt { get; set; }
+
+        [JsonProperty(PropertyName = "currency_code")]
+        public string CurrencyCode { get; set; }
+    }
+}

--- a/Riskified.SDK/Model/OrderElements/AccountBalanceServiceName.cs
+++ b/Riskified.SDK/Model/OrderElements/AccountBalanceServiceName.cs
@@ -1,0 +1,24 @@
+using System.Runtime.Serialization;
+
+namespace Riskified.SDK.Model.OrderElements
+{
+    public enum AccountBalanceServiceName
+    {
+        [EnumMember(Value = "plaid")]
+        Plaid,
+        [EnumMember(Value = "mx")]
+        Mx,
+        [EnumMember(Value = "stripe")]
+        Stripe,
+        [EnumMember(Value = "truelayer")]
+        Truelayer,
+        [EnumMember(Value = "klarna")]
+        Klarna,
+        [EnumMember(Value = "visa")]
+        Visa,
+        [EnumMember(Value = "mastercard")]
+        Mastercard,
+        [EnumMember(Value = "yodlee")]
+        Yodlee
+    }
+}

--- a/Riskified.SDK/Model/OrderElements/AccountIdentity.cs
+++ b/Riskified.SDK/Model/OrderElements/AccountIdentity.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Riskified.SDK.Exceptions;
+using Riskified.SDK.Utils;
+
+namespace Riskified.SDK.Model.OrderElements
+{
+    /// <summary>
+    /// Represents identity information associated with a payment account.
+    /// All fields are optional.
+    /// </summary>
+    public class AccountIdentity : IJsonSerializable
+    {
+        public AccountIdentity() { }
+
+        /// <summary>
+        /// Validates the object's fields content
+        /// </summary>
+        /// <param name="validationType">Should use weak validations or strong</param>
+        /// <exception cref="OrderFieldBadFormatException">throws an exception if one of the parameters doesn't match the expected format</exception>
+        public void Validate(Validations validationType = Validations.Weak)
+        {
+            if (Addresses != null)
+            {
+                foreach (var address in Addresses)
+                {
+                    address.Validate(validationType);
+                }
+            }
+        }
+
+        [JsonProperty(PropertyName = "names")]
+        public List<string> Names { get; set; }
+
+        [JsonProperty(PropertyName = "addresses")]
+        public List<BasicAddress> Addresses { get; set; }
+
+        [JsonProperty(PropertyName = "phone_numbers")]
+        public List<string> PhoneNumbers { get; set; }
+
+        [JsonProperty(PropertyName = "emails")]
+        public List<string> Emails { get; set; }
+    }
+}

--- a/Riskified.SDK/Model/OrderElements/BankWirePaymentDetails.cs
+++ b/Riskified.SDK/Model/OrderElements/BankWirePaymentDetails.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using Riskified.SDK.Exceptions;
 using Riskified.SDK.Utils;
+using System.Collections.Generic;
 
 namespace Riskified.SDK.Model.OrderElements
 {
@@ -46,5 +47,11 @@ namespace Riskified.SDK.Model.OrderElements
 
         [JsonProperty(PropertyName = "payment_type")]
         public PaymentType PaymentType { get; } = PaymentType.BankTransfer;
+
+        [JsonProperty(PropertyName = "account_identity")]
+        public AccountIdentity AccountIdentity { get; set; }
+
+        [JsonProperty(PropertyName = "account_balance")]
+        public AccountBalance AccountBalance { get; set; }
     }
 }

--- a/Riskified.SDK/Riskified.SDK.csproj
+++ b/Riskified.SDK/Riskified.SDK.csproj
@@ -9,7 +9,7 @@
     
     <!-- NuGet Package Properties -->
     <PackageId>Riskified.SDK</PackageId>
-    <Version>5.2.2</Version>
+    <Version>5.3.0</Version>
     <Authors>Riskified</Authors>
     <Company>Riskified</Company>
     <Product>Riskified.SDK</Product>

--- a/Riskified.SDK/Riskified.SDK.csproj
+++ b/Riskified.SDK/Riskified.SDK.csproj
@@ -9,7 +9,7 @@
     
     <!-- NuGet Package Properties -->
     <PackageId>Riskified.SDK</PackageId>
-    <Version>5.2.1</Version>
+    <Version>5.2.2</Version>
     <Authors>Riskified</Authors>
     <Company>Riskified</Company>
     <Product>Riskified.SDK</Product>


### PR DESCRIPTION
## 📌 Related Issues: [DEV-131521](https://riskified.atlassian.net/browse/DEV-131521)

## ✅ Type of Change

- [x] 🚀 Feature
- [ ] 🐛 Bugfix
- [ ] 🔨 Refactor
- [ ] 🧪 Tests
- [ ] 🧹 Chore / Maintenance
- [ ] 📄 Documentation

## 📝 Problem Statement

`BankWirePaymentDetails` lacked support for `account_identity` and `account_balance` objects, which are needed to pass account holder identity information and real-time balance data (via providers like Plaid, MX, etc.) on bank transfer/ACH orders.

## 📝 Solution Overview

Added two new optional properties to `BankWirePaymentDetails`:

- **`AccountIdentity`** — holds names, addresses, phone numbers and emails associated with the payment account
- **`AccountBalance`** — holds available balance, service provider (enum), timestamp and currency code

**New files:**
- `AccountIdentity.cs` — model with 4 optional fields (`Names`, `Addresses`, `PhoneNumbers`, `Emails`)
- `AccountBalance.cs` — model with 4 required fields (`AvailableBalance`, `ServiceName`, `UpdatedAt`, `CurrencyCode`)
- `AccountBalanceServiceName.cs` — enum for the `service_name` field (`Plaid`, `Mx`, `Stripe`, `Truelayer`, `Klarna`, `Visa`, `Mastercard`, `Yodlee`)

**Modified:**
- `BankWirePaymentDetails.cs` — added `AccountIdentity` and `AccountBalance` properties

[DEV-131521]: https://riskified.atlassian.net/browse/DEV-131521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ